### PR TITLE
standardize vim.log.levels output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Make it compatible with `mini.notify` plugin.
+
 ## [v0.4.2](https://github.com/epwalsh/pomo.nvim/releases/tag/v0.4.2) - 2023-12-27
 
 ### Added

--- a/lua/pomo/notifiers/default.lua
+++ b/lua/pomo/notifiers/default.lua
@@ -84,7 +84,7 @@ DefaultNotifier.tick = function(self, time_left)
         util.format_time(time_left),
         self.timer.paused and " (paused)" or ""
       ),
-      "info",
+      vim.log.levels.INFO,
       false
     )
   end
@@ -96,19 +96,19 @@ DefaultNotifier.start = function(self)
   if not self.sticky then
     timeout = 1000
   end
-  self:_update(string.format(" %s  starting...", self.text_icon), "info", timeout)
+  self:_update(string.format(" %s  starting...", self.text_icon), vim.log.levels.INFO, timeout)
 end
 
 DefaultNotifier.done = function(self)
-  self:_update(string.format(" %s  timer done!", self.text_icon), "warn", 3000)
+  self:_update(string.format(" %s  timer done!", self.text_icon), vim.log.levels.WARN, 3000)
 end
 
 DefaultNotifier.stop = function(self)
-  self:_update(string.format(" %s  stopping...", self.text_icon), "info", 1000)
+  self:_update(string.format(" %s  stopping...", self.text_icon), vim.log.levels.INFO, 1000)
 end
 
 DefaultNotifier.hide = function(self)
-  self:_update(nil, "info", 100)
+  self:_update(nil, vim.log.levels.INFO, 100)
   self.sticky = false
 end
 


### PR DESCRIPTION
Just made a small commit to standardize the output of `vim.log.levels.INFO` and `vim.log.levels.WARN`. This change ensures compatibility with `mini.notify`, which strictly aligns with `vim.notify`, requiring the `level` parameter to be of type integer or nil. The explanation of the issue in here [#640](https://github.com/echasnovski/mini.nvim/issues/640#issuecomment-1878354167).

From the help:

```lua
vim.notify({msg}, {level}, {opts})                              *vim.notify()*
 {level}  (integer|nil) One of the values from |vim.log.levels|.
```

Please note that this adjustment doesn't impact other methods like vanilla `vim.notify` and `nvim-notify`. 