### PR TITLE
loading dropdown theme is handled internally now

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,7 @@ Pomo.nvim ships with a telescope extension for managing timers. Here's an exampl
 require("telescope").load_extension "pomodori"
 
 vim.keymap.set("n", "<leader>pt", function()
-  require("telescope").extensions.pomodori.timers(
-    require("telescope.themes").get_dropdown()
-  )
+  require("telescope").extensions.pomodori.timers()
 end, { desc = "Manage Pomodori Timers"})
 ```
 


### PR DESCRIPTION
I forgot to tell you that the theme does no longer need to be loaded in that call since I found a way to get it working internally by wrapping the call to timers in a function - I guess that prevents some default config to be loaded. Anyways, it should work and look good without that bit of code since the argument is no longer passed to the actual function call anyways.