### PR TITLE
Fixes issue #31

### DIFF
--- a/lua/pomo/util.lua
+++ b/lua/pomo/util.lua
@@ -31,17 +31,17 @@ M.format_time = function(time_left)
     return string.format("%ds", time_left)
   elseif time_left <= 300 then
     if math.fmod(time_left, 60) == 0 then
-      return os.date("%Mm", time_left) ---@diagnostic disable-line: return-type-mismatch
+      return os.date("!%Mm", time_left) ---@diagnostic disable-line: return-type-mismatch
     else
-      return os.date("%Mm %Ss", time_left) ---@diagnostic disable-line: return-type-mismatch
+      return os.date("!%Mm %Ss", time_left) ---@diagnostic disable-line: return-type-mismatch
     end
   elseif time_left < 3600 then
-    return os.date("%Mm", time_left) ---@diagnostic disable-line: return-type-mismatch
+    return os.date("!%Mm", time_left) ---@diagnostic disable-line: return-type-mismatch
   else
     if math.fmod(time_left, 3600) == 0 then
-      return os.date("%Hh", time_left) ---@diagnostic disable-line: return-type-mismatch
+      return os.date("!%Hh", time_left) ---@diagnostic disable-line: return-type-mismatch
     else
-      return os.date("%Hh %Mm", time_left) ---@diagnostic disable-line: return-type-mismatch
+      return os.date("!%Hh %Mm", time_left) ---@diagnostic disable-line: return-type-mismatch
     end
   end
 end


### PR DESCRIPTION
Forces os.date to use UTC instead of using local time
os.date using local timezone to format the timestring was causing the display time to have additional hrs/mins
Using UTC fixes this issue #31 